### PR TITLE
Minor amendment to ExprEvaluatorTest.compareNulls to compare right-hand side nulls as well

### DIFF
--- a/core-api/src/test/java/com/absmartly/sdk/jsonexpr/ExprEvaluatorTest.java
+++ b/core-api/src/test/java/com/absmartly/sdk/jsonexpr/ExprEvaluatorTest.java
@@ -208,6 +208,15 @@ class ExprEvaluatorTest extends TestUtils {
 		assertNull(evaluator.compare(null, "abc"));
 		assertNull(evaluator.compare(null, EMPTY_MAP));
 		assertNull(evaluator.compare(null, EMPTY_LIST));
+
+		assertNull(evaluator.compare(0, null));
+		assertNull(evaluator.compare(1, null));
+		assertNull(evaluator.compare(true, null));
+		assertNull(evaluator.compare(false, null));
+		assertNull(evaluator.compare("", null));
+		assertNull(evaluator.compare("abc", null));
+		assertNull(evaluator.compare(EMPTY_MAP, null));
+		assertNull(evaluator.compare(EMPTY_LIST, null));
 	}
 
 	@Test


### PR DESCRIPTION
I found it while implementing tests for .NET SDK that right-hand side nulls aren't covered by tests.
This was implemented in .NET SDK, adding test cases here in Java SDK as well.